### PR TITLE
[일기 작성] 다이어리 상세보기로 화면 전환 부분 수정

### DIFF
--- a/app/src/main/java/com/engdiary/mureng/constant/IntentKey.kt
+++ b/app/src/main/java/com/engdiary/mureng/constant/IntentKey.kt
@@ -5,4 +5,5 @@ object IntentKey {
     const val QUESTION = "question"
     const val QUESTION_ID = "questionID"
     const val DIARY = "DIARY"
+    val EDITED_DIARY = Pair("EDITED_DIARY_KEY", "EDITED_DIARY_VALUE")
 }

--- a/app/src/main/java/com/engdiary/mureng/ui/write_diary/WriteDiaryImageActivity.kt
+++ b/app/src/main/java/com/engdiary/mureng/ui/write_diary/WriteDiaryImageActivity.kt
@@ -98,11 +98,24 @@ class WriteDiaryImageActivity :
             diaryImageAdapter.submitList(it)
         }
 
-        viewModel.navigateToDiaryDetail.observe(this) { diary ->
-            Intent(this, DiaryDetailActivity::class.java)
-                .putExtra(IntentKey.DIARY_CONTENT, diary)
-                .also { startActivity(it) }
+        viewModel.navigateToNewDiaryDetail.observe(this) { diary ->
+            navigateToDiaryDetail(diary, false)
         }
+
+        viewModel.navigateToEditedDiaryDetail.observe(this) { diary ->
+            navigateToDiaryDetail(diary, true)
+        }
+    }
+
+    private fun navigateToDiaryDetail(diary: Diary, isDiaryEdited: Boolean) {
+        val intent = Intent(this, DiaryDetailActivity::class.java)
+            .putExtra(IntentKey.DIARY, diary)
+        if (isDiaryEdited) intent.putExtra(
+            IntentKey.EDITED_DIARY.first,
+            IntentKey.EDITED_DIARY.second
+        )
+        startActivity(intent)
+        finish()
     }
 
     companion object {

--- a/app/src/main/java/com/engdiary/mureng/ui/write_diary/WriteDiaryImageViewModel.kt
+++ b/app/src/main/java/com/engdiary/mureng/ui/write_diary/WriteDiaryImageViewModel.kt
@@ -33,9 +33,13 @@ class WriteDiaryImageViewModel @ViewModelInject constructor(
     private var question: Question? = null
     private var editingDiaryId: Int? = null
 
-    private val _navigateToDiaryDetail = SingleLiveEvent<Diary>()
-    val navigateToDiaryDetail: LiveData<Diary>
-        get() = _navigateToDiaryDetail
+    private val _navigateToNewDiaryDetail = SingleLiveEvent<Diary>()
+    val navigateToNewDiaryDetail: LiveData<Diary>
+        get() = _navigateToNewDiaryDetail
+
+    private val _navigateToEditedDiaryDetail = SingleLiveEvent<Diary>()
+    val navigateToEditedDiaryDetail: LiveData<Diary>
+        get() = _navigateToEditedDiaryDetail
 
     init {
         viewModelScope.launch {
@@ -76,15 +80,15 @@ class WriteDiaryImageViewModel @ViewModelInject constructor(
                 question?.questionId!!,
                 diaryContent.value!!,
                 imagePath!!
-            )?.let { diary -> _navigateToDiaryDetail.value = diary }
-                .run { _navigateToDiaryDetail.call() }
+            )?.let { diary -> _navigateToEditedDiaryDetail.value = diary }
+                .run { _navigateToEditedDiaryDetail.call() }
             return
         }
 
         imagePath?.let {
             murengRepository.postDiary(diaryContent.value!!, it)
-                ?.let { diary -> _navigateToDiaryDetail.value = diary }
-                .run { _navigateToDiaryDetail.call() }
+                ?.let { diary -> _navigateToNewDiaryDetail.value = diary }
+                .run { _navigateToNewDiaryDetail.call() }
         }
     }
 


### PR DESCRIPTION
다이어리를 수정한 후 넘어가는 것인지, 새로운 다이어리를 생성한 후 넘어가는 것인지 값을 같이 전달하도록 구현함
두개의 SingleLiveData를 활용해서 수정한 경우에 호출하는 것과 새로 만든 경우에 호출하는 것을 나눔
수정한 다이어리의 경우에는 IntentKey.kt의 EDITED_DIARY를 추가적으로 보내도록 수정