### PR TITLE
[FIX][다이어리 작성하기] 50자 미만 작성하면 다이어리 작성 버튼을 비활성화해서 앱이 꺼지는 버그 해결

### DIFF
--- a/app/src/main/res/layout/activity_write_diary_content.xml
+++ b/app/src/main/res/layout/activity_write_diary_content.xml
@@ -45,6 +45,7 @@
                     android:layout_marginEnd="17dp"
                     android:text="@string/writingdiary_nextbutton"
                     android:textAppearance="@style/TextAppearance.WritingDiary.Next"
+                    android:enabled="@{viewModel.isDiaryContentConditionSatisfied()}"
                     android:textColor="@{viewModel.isDiaryContentConditionSatisfied() ? @color/pinkpink : @color/pink2}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
### 앱이 꺼지는 이유
다이어리 작성시 50글자 미만이어도 다이어리 작성하기 버튼을 누를 수 있어서,
다이어리 내용이 50글자 미만일 때 작성하기 버튼을 누르면, `DiaryContent`에 해당 다이어리 내용을 저장하고자 시도한다.
따라서 `DiaryContent`의 제약조건에 걸려서 앱이 죽게 되었던 것이었다.

### 해결 방법
다이어리 내용이 50글자 미만일 때는 다이어리 작성하기 버튼을 비활성화 시켜서 버튼을 누를 수 없도록 만들었다.