### PR TITLE
suhyeon/feature/write_diary

### DIFF
--- a/app/src/main/java/com/engdiary/mureng/util/NotificationUtils.kt
+++ b/app/src/main/java/com/engdiary/mureng/util/NotificationUtils.kt
@@ -36,6 +36,7 @@ fun NotificationManager.sendNotification(
     notificationBuilder.setContentTitle(remoteMessage.notification?.title)
         .setContentText(remoteMessage.notification?.body)
         .setContentIntent(pendingIntent)
+        .setSmallIcon(R.drawable.icon_push_alert)
         .setAutoCancel(true)
 
     notify(NOTIFICATION_ID, notificationBuilder.build())


### PR DESCRIPTION
AndroidManifest파일에 지정해놓은 default icon이 상황에 따라서 적용이 안되는 문제가 발생했다.
따라서 다음과 같이, 푸시 알람 생성시 setSmallIcon()을 명시적으로 호출하여 아이콘이 반드시 지정되도록 수정했다.
``` Kotlin
notificationBuilder.setContentTitle(remoteMessage.notification?.title)
        .setContentText(remoteMessage.notification?.body)
        .setContentIntent(pendingIntent)
        .setSmallIcon(R.drawable.icon_push_alert)
        .setAutoCancel(true)
```