### PR TITLE
suhyeon/feature/write_diary

### DIFF
--- a/app/src/main/java/com/engdiary/mureng/ui/write_diary/WriteDiaryImageViewModel.kt
+++ b/app/src/main/java/com/engdiary/mureng/ui/write_diary/WriteDiaryImageViewModel.kt
@@ -95,7 +95,6 @@ class WriteDiaryImageViewModel @ViewModelInject constructor(
         imagePath?.let {
             murengRepository.postDiary(question.value?.questionId!!, diaryContent.value!!, it)
                 ?.let { diary -> _navigateToNewDiaryDetail.value = diary }
-                .run { _navigateToNewDiaryDetail.call() }
         }
     }
 


### PR DESCRIPTION
 다이어리 작성시에 이미지 선택 후 [등록] 버튼 누르고 나서 다음 화면으로 넘어가지 않는 문제를 해결했다.

## 문제 원인
_navigateToDiaryDetail에 Diary를 설정하여 WriteDiaryImageActivity에서 이 Diary를 받아서 DiaryDetailActivity로 넘어가도록 구현했다.
하지만 _navigateToDiaryDetail에 Diary를 설정한 이후 call()을 한번더 호출하도록 코드가 되어있었다.
따라서 새로운 Diary객체가 등록되더라도 마지막에 call()이 호출되면, 마지막의 call()이 적용되어서 DiaryDetailActivity로 넘어가지 못하는 문제가 발생하게 되었다.

## 해결 방식
마지막의 _navgateToDiary.call() 코드를 제거하여, 새로운 Diary를 넘기는 코드만 남겨두었다.